### PR TITLE
More SmartPointer tests

### DIFF
--- a/lessons/smart-pointers/Makefile
+++ b/lessons/smart-pointers/Makefile
@@ -2,7 +2,7 @@ SHELL:=/bin/bash
 .phony: all clean
 
 CFLAGS=-std=c++11
-COMPILE=g++ -c ${CFLAGS}
+COMPILE=g++ -g -c ${CFLAGS}
 LINK=g++ ${CFLAGS}
 
 all: build/main
@@ -18,7 +18,8 @@ build/main.o: src/main.cpp
 	${COMPILE} -o build/main.o src/main.cpp
 
 test: build/main
-	diff <(./build/main) out.txt && echo SUCCESS || echo FAIL
+	diff <(./build/main) out.txt && echo "PASS OUTPUT" || echo "FAIL OUTPUT"
+	valgrind --error-exitcode=1 --quiet --leak-resolution=low --leak-check=full --show-possibly-lost=no ./build/main > /dev/null && echo "PASS VALGRIND" || echo "FAIL VALGRIND"
 
 clean:
 	rm -rf build/*

--- a/lessons/smart-pointers/out.txt
+++ b/lessons/smart-pointers/out.txt
@@ -22,3 +22,11 @@ DATA: ~A(6)
 TEST: 5
 DATA: A(7)
 DATA: ~A(7)
+TEST: 6
+DATA: A(8)
+INFO: A(8) Should not be deleted
+DATA: ~A(8)
+TEST: 7
+DATA: A(9)
+DATA: ~A(9)
+INFO: A(9) Should be deleted

--- a/lessons/smart-pointers/src/macros.h
+++ b/lessons/smart-pointers/src/macros.h
@@ -19,3 +19,4 @@ using std::endl;
 
 #define PRINT(Str) \
   cout << Str << endl;
+

--- a/lessons/smart-pointers/src/main.cpp
+++ b/lessons/smart-pointers/src/main.cpp
@@ -26,6 +26,7 @@ class SmartPointer {
 private:
     PointerBox* pb;
 public:
+    SmartPointer(): pb(nullptr) {}
     SmartPointer(A* a): pb(new PointerBox(a)) {}
     A* operator->();
     SmartPointer operator=(const SmartPointer& p);
@@ -83,6 +84,17 @@ int main() {
     TEST(5)
     {
         SmartPointer spA = make(7);
+    }
+
+    TEST(6)
+    {
+        SmartPointer spA;
+        SmartPointer spB;
+
+        spA = make(8);
+        spB = spA;
+
+        INFO("A(8) Should not be deleted");
     }
 
     return 0;

--- a/lessons/smart-pointers/src/main.cpp
+++ b/lessons/smart-pointers/src/main.cpp
@@ -97,5 +97,15 @@ int main() {
         INFO("A(8) Should not be deleted");
     }
 
+    TEST(7)
+    {
+        SmartPointer spA = make(9);
+        SmartPointer spB;
+
+        spA = spB;
+
+        INFO("A(9) Should be deleted");
+    }
+
     return 0;
 }


### PR DESCRIPTION
 * Test the sample code for memory leaks/errors
 * Add a default constructor for SmartPointer, which adds more edge cases the coder must handle
 * _(minor)_ Fix return value of SmartPointer operator=()
 * _(minor)_ Silence compiler warning in macros.h